### PR TITLE
Add support for custom module/theme paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
   },
   "require": {
     "composer/installers": "^1.0",
+    "oomphinc/composer-installers-extender": "^1.1",
     "drupal-composer/drupal-scaffold": "^2.2",
     "zendframework/zend-stdlib": "~3.0.1",
     "cweagans/composer-patches": "^1.5",
@@ -65,6 +66,10 @@
     }
   },
   "extra": {
+    "installer-types": [
+      "drupal-custom-module",
+      "drupal-custom-theme"
+    ],
     "installer-paths": {
       "web/core": [
         "drupal/core"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "drupal/console": "~1.0"
     },
     "require": {
-        "composer/installers": "^1.0",
         "oomphinc/composer-installers-extender": "^1.1",
         "drupal-composer/drupal-scaffold": "^2.2",
         "zendframework/zend-stdlib": "~3.0.1",


### PR DESCRIPTION
Without the `oomphinc/composer-installers-extender` library, the custom
theme/module paths declared in extra "installer-paths" had no effect.