### PR TITLE
Added Drupal Core as a dependency for the installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "drupal-composer/drupal-scaffold": "^2.2",
         "zendframework/zend-stdlib": "~3.0.1",
         "cweagans/composer-patches": "^1.5",
+        "drupal/core": "~8.4",
         "ucdavis/sitefarm_seed": "dev-8.x-1.x"
     },
     "repositories": {


### PR DESCRIPTION
Added the following to the composer.json file:

```
        "drupal/core": "~8.4",
```

As a requirement for the installer this should take any confusion out of composer.

Should solve #18 