### PR TITLE
Docksal configuration improvements.

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -1,52 +1,52 @@
 #!/usr/bin/env bash
 
-#-------------------------- Settings --------------------------------
+#!/usr/bin/env bash
 
-# PROJECT_ROOT is passed from fin.
-# The following variables are configured in the '.env' file: DOCROOT, VIRTUAL_HOST.
+## Initialize stack and site (full reset)
+##
+## Usage: fin init
 
-SITE_DIRECTORY="default"
-DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-SITEDIR_PATH="${DOCROOT_PATH}/sites/${SITE_DIRECTORY}"
+# Abort if anything fails
+set -e
 
-#-------------------------- END: Settings --------------------------------
+#-------------------------- Helper functions --------------------------------
 
-# Set docksal-local.env
-cp $PROJECT_ROOT/.docksal/example.docksal-local.env $PROJECT_ROOT/.docksal/docksal-local.env
-# Start containers
-fin up
-# Install
-fin exec composer install
-# Set local config files
-cp $SITEDIR_PATH/default.settings.php $SITEDIR_PATH/settings.php
-cp $SITEDIR_PATH/default.settings.local.php $SITEDIR_PATH/settings.local.php
-cp $SITEDIR_PATH/default.services.local.yml $SITEDIR_PATH/services.local.yml
-# Set extra config
-echo "
+# Console colors
+red='\033[0;31m'
+green='\033[0;32m'
+green_bg='\033[42m'
+yellow='\033[1;33m'
+NC='\033[0m'
 
- if (file_exists(\$app_root . '/' . \$site_path . '/settings.local.php')) {
-   include \$app_root . '/' . \$site_path . '/settings.local.php';
- }
-" >> $SITEDIR_PATH/settings.php
-echo "
-\$databases['default']['default'] = array (
-  'database' => 'default',
-  'username' => 'user',
-  'password' => 'user',
-  'prefix' => '',
-  'host' => '$(fin vm ip)',
-  'port' => '33062',
-  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-  'driver' => 'mysql',
-);
-" >> $SITEDIR_PATH/settings.local.php
+echo-red () { echo -e "${red}$1${NC}"; }
+echo-green () { echo -e "${green}$1${NC}"; }
+echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
+echo-yellow () { echo -e "${yellow}$1${NC}"; }
+
+#-------------------------- Execution --------------------------------
+# Stack initialization
+echo -e "${green_bg} Step 1 ${NC}${green} Initializing stack...${NC}"
+if [[ ${DOCKER_RUNNING} == "true" ]]; then
+	fin reset -f
+else
+	fin up
+fi
+echo "Waiting 10s for MySQL to initialize...";
+sleep 10
+
+# Site initialization
+echo -e "${green_bg} Step 2 ${NC}${green} Initializing site...${NC}"
+
+# This runs inside cli using http://docs.docksal.io/en/v1.4.0/fin/custom-commands/#executing-commands-inside-cli
+fin init-site
+
+echo -en "${green_bg} ALMOST DONE! ${NC} "
+echo -e "Open ${yellow}http://${VIRTUAL_HOST}${NC} in your browser to verify the setup."
+
 # Set hosts
-fin hosts remove $VIRTUAL_HOST
-fin hosts add $VIRTUAL_HOST
-# Install site
-cd $DOCROOT
-fin drush site-install sitefarm_subprofile -y --site-name="SiteFarm Distro"
-# Get login link
-fin drush uli --uri="http://$VIRTUAL_HOST"
-# Set permissions
-sudo chmod 755 $SITEDIR_PATH
+fin hosts remove ${VIRTUAL_HOST}
+fin hosts add ${VIRTUAL_HOST}
+
+echo -en "${green_bg} DONE! ${NC} "
+fin drush uli
+#-------------------------- END: Execution --------------------------------

--- a/.docksal/commands/init-site
+++ b/.docksal/commands/init-site
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#: exec_target = cli
+
+## Initialize/reinstall site
+##
+## Usage: fin init-site
+
+# Abort if anything fails
+set -e
+
+#-------------------------- Settings --------------------------------
+
+# PROJECT_ROOT is passed from fin.
+# The following variables are configured in the '.env' file: DOCROOT, VIRTUAL_HOST.
+
+SITE_DIRECTORY="default"
+DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
+SITEDIR_PATH="${DOCROOT_PATH}/sites/${SITE_DIRECTORY}"
+
+#-------------------------- END: Settings --------------------------------
+
+# Set docksal-local.env
+cp ${PROJECT_ROOT}/.docksal/example.docksal-local.env ${PROJECT_ROOT}/.docksal/docksal-local.env
+
+# Install
+composer global require hirak/prestissimo
+cd ${PROJECT_ROOT}
+composer install
+
+# Set local config files
+cp ${SITEDIR_PATH}/default.settings.php ${SITEDIR_PATH}/settings.php
+cp ${SITEDIR_PATH}/default.settings.local.php ${SITEDIR_PATH}/settings.local.php
+cp ${SITEDIR_PATH}/default.services.local.yml ${SITEDIR_PATH}/services.local.yml
+
+# Set extra config
+echo "
+
+ if (file_exists(\$app_root . '/' . \$site_path . '/settings.local.php')) {
+   include \$app_root . '/' . \$site_path . '/settings.local.php';
+ }
+" >> ${SITEDIR_PATH}/settings.php
+echo "
+\$databases['default']['default'] = array (
+  'database' => 'default',
+  'username' => 'user',
+  'password' => 'user',
+  'prefix' => '',
+  'host' => 'db',
+  'port' => '3306',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'driver' => 'mysql',
+);
+" >> ${SITEDIR_PATH}/settings.local.php
+
+# Install site
+cd ${DOCROOT_PATH}
+
+drush site-install sitefarm_subprofile -y --site-name="SiteFarm Distro"
+
+# Set permissions
+sudo chmod 755 ${SITEDIR_PATH}

--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -9,7 +9,7 @@
 # Lock images versions for LAMP services
 # This will prevent images from being updated when Docksal is updated
 WEB_IMAGE='docksal/web:2.0-apache2.4'
-DB_IMAGE='docksal/db:1.1-mysql-5.6'
+DB_IMAGE='docksal/db:1.1-mysql-5.7'
 CLI_IMAGE='docksal/cli:1.3-php7'
 
 # Docksal configuration.

--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -22,6 +22,10 @@ services:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: cli
+    environment:
+      - VIRTUAL_HOST
+    volumes:
+      - ${PROJECT_ROOT}/.docksal/etc/drush:/etc/drush:ro
 
   # Browser
   browser:

--- a/.docksal/etc/drush/drushrc.php
+++ b/.docksal/etc/drush/drushrc.php
@@ -1,0 +1,4 @@
+<?php
+
+$uri = getenv('VIRTUAL_HOST');
+$options['uri'] = 'http://' . $uri;

--- a/.docksal/etc/mysql/my.cnf
+++ b/.docksal/etc/mysql/my.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+
+# Enable slow query logging
+#long_query_time=1
+#slow_query_log=1
+#slow_query_log_file=/dev/stdout


### PR DESCRIPTION
Improved the docksal configuration:

* Added `drushrc.php` to container so that when you run `fin drush uli` it will tack the *$VIRTUAL_HOST* onto the URL
* Changed the database connection injection (snippet in `init` command) to map to the `db` container internally
* Automated the deletion / creation of the project containers.
* Added `hirak/prestissimo` to the `cli` container to help speed up 
* Moved most code from the `init` command to `init-site` which can execute inside of the container with the `#: exec_target = cli` line
* Modified all script variables to be wrapped in { } as to cause no possible confusion in bash variables.